### PR TITLE
Feat/register view

### DIFF
--- a/MyMemory/MyMemory.xcodeproj/project.pbxproj
+++ b/MyMemory/MyMemory.xcodeproj/project.pbxproj
@@ -15,13 +15,13 @@
 		01E6A6352B467FE80061F08C /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E6A6342B467FE80061F08C /* MainTabView.swift */; };
 		01E6A6392B46813E0061F08C /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E6A6382B46813E0061F08C /* LoginView.swift */; };
 		01E6A6402B4681DC0061F08C /* MypageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E6A63F2B4681DC0061F08C /* MypageView.swift */; };
-		01E6A6432B4683090061F08C /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E6A6422B4683090061F08C /* PostView.swift */; };
 		28F26D3F2B551E8500CE783D /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F26D3E2B551E8500CE783D /* LoginViewModel.swift */; };
 		6A7BA0462B51050F00BEE111 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BA0452B51050F00BEE111 /* SettingView.swift */; };
 		6A7BA0482B51052E00BEE111 /* SettingMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BA0472B51052E00BEE111 /* SettingMenuCell.swift */; };
 		6A7BA04B2B51055700BEE111 /* WithdrawalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BA04A2B51055700BEE111 /* WithdrawalView.swift */; };
 		6A7BA04E2B5105DC00BEE111 /* MypageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BA04D2B5105DC00BEE111 /* MypageViewModel.swift */; };
 		6A7BA0502B51060300BEE111 /* MemoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BA04F2B51060300BEE111 /* MemoList.swift */; };
+		9D1775182B554C4300BC8F5A /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1775172B554C4300BC8F5A /* RegisterViewModel.swift */; };
 		9D9D40CB2B4C184F00E9AA76 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9D40CA2B4C184F00E9AA76 /* RegisterView.swift */; };
 		DA131A482B4AB19700743FD0 /* MemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA131A472B4AB19700743FD0 /* MemoModel.swift */; };
 		DA131A4C2B4BD4BA00743FD0 /* MapViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA131A4B2B4BD4BA00743FD0 /* MapViewModelTest.swift */; };
@@ -79,13 +79,13 @@
 		01E6A6342B467FE80061F08C /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		01E6A6382B46813E0061F08C /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		01E6A63F2B4681DC0061F08C /* MypageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageView.swift; sourceTree = "<group>"; };
-		01E6A6422B4683090061F08C /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
 		28F26D3E2B551E8500CE783D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		6A7BA0452B51050F00BEE111 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		6A7BA0472B51052E00BEE111 /* SettingMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingMenuCell.swift; sourceTree = "<group>"; };
 		6A7BA04A2B51055700BEE111 /* WithdrawalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalView.swift; sourceTree = "<group>"; };
 		6A7BA04D2B5105DC00BEE111 /* MypageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewModel.swift; sourceTree = "<group>"; };
 		6A7BA04F2B51060300BEE111 /* MemoList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoList.swift; sourceTree = "<group>"; };
+		9D1775172B554C4300BC8F5A /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		9D9D40CA2B4C184F00E9AA76 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		DA131A472B4AB19700743FD0 /* MemoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoModel.swift; sourceTree = "<group>"; };
 		DA131A4B2B4BD4BA00743FD0 /* MapViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelTest.swift; sourceTree = "<group>"; };
@@ -201,6 +201,7 @@
 				01E6A6382B46813E0061F08C /* LoginView.swift */,
 				28F26D3E2B551E8500CE783D /* LoginViewModel.swift */,
 				9D9D40CA2B4C184F00E9AA76 /* RegisterView.swift */,
+				9D1775172B554C4300BC8F5A /* RegisterViewModel.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -534,6 +535,7 @@
 				DA3C24F22B55079E00425288 /* MemoView.swift in Sources */,
 				014CB5762B46A2B50016DF70 /* Report.swift in Sources */,
 				01E6A6402B4681DC0061F08C /* MypageView.swift in Sources */,
+				9D1775182B554C4300BC8F5A /* RegisterViewModel.swift in Sources */,
 				DAB3154B2B43EFDB000357C7 /* MyMemoryApp.swift in Sources */,
 				DA78940B2B44090400DC3771 /* MainMapView.swift in Sources */,
 				DA3C24F72B55079E00425288 /* PostView.swift in Sources */,

--- a/MyMemory/MyMemory/View/Authentication/RegisterView.swift
+++ b/MyMemory/MyMemory/View/Authentication/RegisterView.swift
@@ -8,9 +8,186 @@
 import SwiftUI
 
 struct RegisterView: View {
+//    @ObservedObject var viewModel: LoginViewModel = LoginViewModel()
+    @State var email : String = ""
+    @State var password : String = ""
+    @State var name : String = ""
+    @State var emailValid : Bool = true
+    @State var passwordValid : Bool = true
+    @State var rule1 : Bool = false
+    @State var rule2 : Bool = false
+    @State var rule3 : Bool = false
+    @State var rule4 : Bool = false
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            ScrollView {
+                VStack() {
+                    Spacer()
+                    Image(systemName: "person.circle.fill")
+                        .resizable()
+                        .frame(width:180, height: 180)
+                        .foregroundStyle(Color.gray)
+                        .onTapGesture {
+                            print("hello world")
+                        }
+                    Spacer()
+                    Spacer()
+                    VStack(alignment: .leading) {
+                        VStack(alignment: .leading) {
+                            Text("이메일")
+                                .font(.system(size: 15))
+                            TextField("example@example.com", text: $email)
+                                .overlay(
+                                        Image(systemName: "multiply.circle.fill")
+                                            .position(x:350, y:10)
+                                            .foregroundStyle(Color.gray)
+                                            .onTapGesture {
+                                                self.email = ""
+                                            }
+                                )
+                            
+                            Divider()
+                                .padding(.vertical, -5)
+                            HStack {
+                                Text(checkEmail(email: email) ? "사용 가능한 이메일입니다!" : "사용할수 없는 이메일입니다")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(email == "" ? Color.white : (checkEmail(email: email) ? Color.green : Color.red))
+                            }
+                        }
+                        .padding()
+                        
+                        VStack(alignment: .leading) {
+                            Text("비밀번호")
+                                .font(.system(size: 15))
+                            TextField("특수문자와 숫자/대문자를 포함한 8글자", text: $password)
+                                .overlay(
+                                        Image(systemName: "multiply.circle.fill")
+                                            .position(x:350, y:10)
+                                            .foregroundStyle(Color.gray)
+                                            .onTapGesture {
+                                                password = ""
+                                            }
+                                )
+                            Divider()
+                                .padding(.vertical, -5)
+                            Text(passwordValid ? "사용 가능한 비밀번호입니다" : "특수문자,숫자,대문자를 포함한 8글자 이상으로 설정하세요!")
+                                .font(.system(size: 15))
+                                .foregroundStyle(password == "" ? Color.white : (passwordValid ? Color.green : Color.red))
+                        }
+                        .padding()
+                        
+                        VStack(alignment: .leading) {
+                            Text("이름")
+                                .font(.system(size: 15))
+                            TextField("이름을 입력해주세요", text: $name)
+                                .overlay(
+                                        Image(systemName: "multiply.circle.fill")
+                                            .position(x:350, y:10)
+                                            .foregroundStyle(Color.gray)
+                                            .onTapGesture {
+                                                self.name = ""
+                                            }
+                                )
+                            Divider()
+                                .padding(.vertical, -5)
+                        }
+                        .padding()
+                        VStack(alignment: .leading) {
+                                        HStack{
+                                            Image(systemName: rule1 ? "checkmark.square" : "square")
+                                                .onTapGesture {
+                                                    rule1.toggle()
+                                                    if rule1 == true {
+                                                        rule2 = true
+                                                        rule3 = true
+                                                        rule4 = true
+                                                    } else {
+                                                        rule2 = false
+                                                        rule3 = false
+                                                        rule4 = false
+                                                    }
+                                                    
+                                                }
+                                            HStack(alignment: .bottom){
+                                                    Text("약관 전체동의")
+                                                        .bold()
+                                                        .font(.system(size: 18))
+                                                    Text("선택항목에 대한 동의 포함")
+                                                        .font(.system(size: 13))
+                                                        .foregroundStyle(Color.gray)
+                                            }
+                                        }
+                            Spacer()
+                            Spacer()
+                                        HStack{
+                                            Image(systemName: rule2 ? "checkmark.square" : "square")
+                                                .onTapGesture {
+                                                    rule2.toggle()
+                                                }
+                                            Text("만 14세 이상입니다")
+                                            Text("(필수)")
+                                                .font(.system(size: 10))
+                                        }
+                                            .font(.system(size: 13))
+                            Spacer()
+                            Spacer()
+                                        HStack{
+                                            Image(systemName: rule3 ? "checkmark.square" : "square")
+                                                .onTapGesture {
+                                                    rule3.toggle()
+                                                }
+                                            Text("이용약관")
+                                            Text("(필수)")
+                                                .font(.system(size: 10))
+                                        }
+                                            .font(.system(size: 13))
+                            
+                            Spacer()
+                            Spacer()
+                                        HStack{
+                                            Image(systemName: rule4 ? "checkmark.square" : "square")
+                                                .onTapGesture {
+                                                    rule4.toggle()
+                                                }
+                                                Text("개인정보수집 및 개인동의")
+                                                Text("(필수)")
+                                                .font(.system(size: 10))
+                                        }
+                                        .font(.system(size: 13))
+                                    }
+                        .overlay(
+                                Rectangle()
+                                    .stroke(Color.gray)
+                                    .frame(width: 360, height: 150)
+                                    .position(x: 180, y: 60)
+                        )
+//                                )
+//                        }
+                        .padding()
+                    }
+                    Spacer()
+                    Spacer()
+                    Spacer()
+                    Spacer()
+                    Button(action: {
+    
+                    }, label: {
+                        Text("회원가입")
+                    })
+                    .frame(width: 360, height: 50)
+                    .background(Color.accentColor)
+                    .cornerRadius(12)
+                    .foregroundStyle(Color.white)
+                }
+                    .navigationBarTitle("회원가입")
+            }
+        }
     }
+}
+
+func checkEmail(email: String) -> Bool {
+    let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
+    return  NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
 }
 
 #Preview {

--- a/MyMemory/MyMemory/View/Authentication/RegisterView.swift
+++ b/MyMemory/MyMemory/View/Authentication/RegisterView.swift
@@ -6,52 +6,61 @@
 //
 
 import SwiftUI
+import Photos
+import PhotosUI
 
 struct RegisterView: View {
-//    @ObservedObject var viewModel: LoginViewModel = LoginViewModel()
-    @State var email : String = ""
-    @State var password : String = ""
-    @State var name : String = ""
-    @State var emailValid : Bool = true
-    @State var passwordValid : Bool = true
-    @State var rule1 : Bool = false
-    @State var rule2 : Bool = false
-    @State var rule3 : Bool = false
-    @State var rule4 : Bool = false
+    @ObservedObject var viewModel: RegisterViewModel = RegisterViewModel()
+    @State private var selectedImageData: Data? = nil
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack() {
                     Spacer()
-                    Image(systemName: "person.circle.fill")
-                        .resizable()
-                        .frame(width:180, height: 180)
-                        .foregroundStyle(Color.gray)
-                        .onTapGesture {
-                            print("hello world")
+                    PhotosPicker(
+                        selection: $viewModel.selectedItem,
+                        matching: .images
+                    ){
+                        if viewModel.imageSelected == false {
+                            Image(systemName: "person.circle.fill")
+                                .resizable()
+                                .frame(width:180, height: 180)
+                                .foregroundStyle(Color.gray)
                         }
+                        else {
+                            if let selectedImageData,
+                               let uiImage = UIImage(data: selectedImageData) {
+                                Image(uiImage: uiImage)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .clipShape(Circle())
+                                    .frame(width: 180, height: 180)
+                            }
+                        }
+                        
+                    }
                     Spacer()
                     Spacer()
                     VStack(alignment: .leading) {
                         VStack(alignment: .leading) {
                             Text("이메일")
                                 .font(.system(size: 15))
-                            TextField("example@example.com", text: $email)
+                            TextField("example@example.com", text: $viewModel.email)
                                 .overlay(
                                         Image(systemName: "multiply.circle.fill")
                                             .position(x:350, y:10)
                                             .foregroundStyle(Color.gray)
                                             .onTapGesture {
-                                                self.email = ""
+                                                viewModel.email = ""
                                             }
                                 )
                             
                             Divider()
                                 .padding(.vertical, -5)
                             HStack {
-                                Text(checkEmail(email: email) ? "사용 가능한 이메일입니다!" : "사용할수 없는 이메일입니다")
+                                Text(viewModel.checkEmail(email: viewModel.email) ? "사용 가능한 이메일입니다!" : "사용할수 없는 이메일입니다")
                                     .font(.system(size: 15))
-                                    .foregroundStyle(email == "" ? Color.white : (checkEmail(email: email) ? Color.green : Color.red))
+                                    .foregroundStyle(viewModel.email == "" ? Color.white : (viewModel.checkEmail(email: viewModel.email) ? Color.green : Color.red))
                             }
                         }
                         .padding()
@@ -59,33 +68,33 @@ struct RegisterView: View {
                         VStack(alignment: .leading) {
                             Text("비밀번호")
                                 .font(.system(size: 15))
-                            TextField("특수문자와 숫자/대문자를 포함한 8글자", text: $password)
+                            SecureField("특수문자와 숫자/대문자를 포함한 8글자", text: $viewModel.password)
                                 .overlay(
                                         Image(systemName: "multiply.circle.fill")
                                             .position(x:350, y:10)
                                             .foregroundStyle(Color.gray)
                                             .onTapGesture {
-                                                password = ""
+                                                viewModel.password = ""
                                             }
                                 )
                             Divider()
                                 .padding(.vertical, -5)
-                            Text(passwordValid ? "사용 가능한 비밀번호입니다" : "특수문자,숫자,대문자를 포함한 8글자 이상으로 설정하세요!")
+                            Text(viewModel.checkPassword(password: viewModel.password) ? "사용 가능한 비밀번호입니다" : "특수문자,숫자,대문자를 포함한 8글자 이상으로 설정하세요!")
                                 .font(.system(size: 15))
-                                .foregroundStyle(password == "" ? Color.white : (passwordValid ? Color.green : Color.red))
+                                .foregroundStyle(viewModel.password == "" ? Color.white : (viewModel.checkPassword(password: viewModel.password) ? Color.green : Color.red))
                         }
                         .padding()
                         
                         VStack(alignment: .leading) {
                             Text("이름")
                                 .font(.system(size: 15))
-                            TextField("이름을 입력해주세요", text: $name)
+                            TextField("이름을 입력해주세요", text: $viewModel.name)
                                 .overlay(
                                         Image(systemName: "multiply.circle.fill")
                                             .position(x:350, y:10)
                                             .foregroundStyle(Color.gray)
                                             .onTapGesture {
-                                                self.name = ""
+                                                viewModel.name = ""
                                             }
                                 )
                             Divider()
@@ -94,17 +103,13 @@ struct RegisterView: View {
                         .padding()
                         VStack(alignment: .leading) {
                                         HStack{
-                                            Image(systemName: rule1 ? "checkmark.square" : "square")
+                                            Image(systemName: viewModel.agreeAllBoxes ? "checkmark.square" : "square")
                                                 .onTapGesture {
-                                                    rule1.toggle()
-                                                    if rule1 == true {
-                                                        rule2 = true
-                                                        rule3 = true
-                                                        rule4 = true
+                                                    viewModel.agreeAllBoxes.toggle()
+                                                    if viewModel.agreeAllBoxes == true {
+                                                        viewModel.checkAllBoxes()
                                                     } else {
-                                                        rule2 = false
-                                                        rule3 = false
-                                                        rule4 = false
+                                                        viewModel.uncheckAllBoxes()
                                                     }
                                                     
                                                 }
@@ -120,9 +125,9 @@ struct RegisterView: View {
                             Spacer()
                             Spacer()
                                         HStack{
-                                            Image(systemName: rule2 ? "checkmark.square" : "square")
+                                            Image(systemName: viewModel.overFourteenBox ? "checkmark.square" : "square")
                                                 .onTapGesture {
-                                                    rule2.toggle()
+                                                    viewModel.overFourteenBox.toggle()
                                                 }
                                             Text("만 14세 이상입니다")
                                             Text("(필수)")
@@ -132,34 +137,59 @@ struct RegisterView: View {
                             Spacer()
                             Spacer()
                                         HStack{
-                                            Image(systemName: rule3 ? "checkmark.square" : "square")
+                                            Image(systemName: viewModel.termsOfUseBox ? "checkmark.square" : "square")
                                                 .onTapGesture {
-                                                    rule3.toggle()
+                                                    viewModel.termsOfUseBox.toggle()
                                                 }
                                             Text("이용약관")
                                             Text("(필수)")
                                                 .font(.system(size: 10))
+                                            Spacer()
+                                            Button(action: {
+                                                viewModel.showPrivacyPolicy = true
+                                            }) {
+                                                Image(systemName: "chevron.forward")
+                                                    .foregroundStyle(Color.gray)
+                                                    .font(.system(size: 15))
+                                                    .padding(.trailing, 20)
+                                            }
+                                            .sheet(isPresented: $viewModel.showPrivacyPolicy) {
+                                                RegisterViewModel.SafariView(url:URL(string: viewModel.privacyPolicyUrlString)!)
+                                            }
                                         }
                                             .font(.system(size: 13))
                             
                             Spacer()
                             Spacer()
                                         HStack{
-                                            Image(systemName: rule4 ? "checkmark.square" : "square")
+                                            Image(systemName: viewModel.privacyPolicyBox ? "checkmark.square" : "square")
                                                 .onTapGesture {
-                                                    rule4.toggle()
+                                                    viewModel.privacyPolicyBox.toggle()
                                                 }
                                                 Text("개인정보수집 및 개인동의")
                                                 Text("(필수)")
                                                 .font(.system(size: 10))
+                                            Spacer()
+                                            Button(action: {
+                                                viewModel.showTermsOfUse = true
+                                            }) {
+                                                Image(systemName: "chevron.forward")
+                                                    .foregroundStyle(Color.gray)
+                                                    .font(.system(size: 15))
+                                                    .padding(.trailing, 20)
+                                            }
+                                            .sheet(isPresented: $viewModel.showTermsOfUse) {
+                                                RegisterViewModel.SafariView(url:URL(string: viewModel.termsOfUseUrlString)!)
+                                            }
                                         }
                                         .font(.system(size: 13))
                                     }
+                        .padding(5)
                         .overlay(
                                 Rectangle()
                                     .stroke(Color.gray)
                                     .frame(width: 360, height: 150)
-                                    .position(x: 180, y: 60)
+                                    .position(x: 180, y: 63)
                         )
 //                                )
 //                        }
@@ -170,7 +200,11 @@ struct RegisterView: View {
                     Spacer()
                     Spacer()
                     Button(action: {
-    
+                        if viewModel.checkIfCanRegister() == true {
+                            print("Register completed")
+                        } else {
+                            print("Register failed")
+                        }
                     }, label: {
                         Text("회원가입")
                     })
@@ -182,14 +216,18 @@ struct RegisterView: View {
                     .navigationBarTitle("회원가입")
             }
         }
+        .onChange(of: viewModel.selectedItem) {newItem in
+            viewModel.imageSelected = true
+            Task {
+                if let data = try? await newItem?.loadTransferable(type: Data.self) {
+                    selectedImageData = data
+                }
+            }
+        }
     }
-}
-
-func checkEmail(email: String) -> Bool {
-    let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
-    return  NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
 }
 
 #Preview {
     RegisterView()
 }
+

--- a/MyMemory/MyMemory/View/Authentication/RegisterViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/RegisterViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  RegisterViewModel.swift
+//  MyMemory
+//
+//  Created by hyunseo on 1/15/24.
+//
+
+import Foundation
+
+import Foundation
+import Photos
+import PhotosUI
+import SwiftUI
+import SafariServices
+
+class RegisterViewModel: ObservableObject {
+
+    @Published var email : String = ""
+    @Published var password : String = ""
+    @Published var name : String = ""
+    
+    @Published var emailValid : Bool = true
+    @Published var passwordValid : Bool = true
+    
+    @Published var agreeAllBoxes : Bool = false
+    @Published var overFourteenBox : Bool = false
+    @Published var termsOfUseBox : Bool = false
+    @Published var privacyPolicyBox : Bool = false
+    
+    @Published var selectedItem: PhotosPickerItem? = nil
+    @Published var imageSelected : Bool = false
+    
+    @Published var showPrivacyPolicy = false
+    @Published var showTermsOfUse = false
+    @Published var privacyPolicyUrlString = "https://www.google.com"
+    @Published var termsOfUseUrlString = "https://www.naver.com"
+    // 현재 개인정보와 이용약관 문서를 정리중입니다. 추후에 완성된 문서의 주소값으로 업데이트 하겠습니다
+    
+    
+    struct SafariView: UIViewControllerRepresentable {
+
+        let url: URL
+
+        func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+            return SFSafariViewController(url: url)
+        }
+
+        func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
+
+        }
+    }
+    
+    func checkPassword(password: String) -> Bool {
+        let passwordRegEx = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#?$%^&*()_+=-]).{7,50}$"
+        return NSPredicate(format:"SELF MATCHES %@", passwordRegEx).evaluate(with: password)
+        
+    }
+    
+    func checkEmail(email: String) -> Bool {
+        let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
+        return  NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
+    }
+    
+    func checkIfCanRegister() -> Bool {
+        if checkPassword(password: password) == true && checkPassword(password: password) == true && name != "" && checkIfAllBoxsesAreChecked() == true {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func checkIfAllBoxsesAreChecked() -> Bool {
+        if overFourteenBox == false || termsOfUseBox == false || privacyPolicyBox == false {
+            return false
+        } else {
+            return true
+        }
+    }
+    
+    func checkAllBoxes() {
+        overFourteenBox = true
+        termsOfUseBox = true
+        privacyPolicyBox = true
+    }
+    
+    func uncheckAllBoxes() {
+        overFourteenBox = false
+        termsOfUseBox = false
+        privacyPolicyBox = false
+    }
+}


### PR DESCRIPTION
[Refactoring] 회원가입뷰 업데이트


[Add]
* 비밀번호, 이메일 형식과 약관동의 부분을 검사하는 함수
* 필요한 정보가 입력이 안되어있을시 회원가입을 막는 함수
* 프로필사진을 올리는 ImagePicker 함수
* 이용약관과 개인정보 정책으로 연결되는 버튼 (이 부분은 정책부분이 아직 구현이 안되어있어서 현재 네이버, 구글로 이동하는 임시 WebView 입니다, 또한 WebKit이 아닌 SafariServices를 이용했는데, WebKit으로 만든것또한 구현을 해놔서 의견을 주시면 교체하겠습니다)


[Refactoring]
* 어중간한 함수, 변수 이름들을 바꿨습니다. (rule1, rule2, rule3...    ->    agreeAllBoxes, overFourteenBox, termsOfUseBox)
* Registerview의 @State 변수들을 뷰모델(RegisterViewModel)로 이동하였습니다