### PR TITLE
[Refactoring]: 이미지 디테일뷰와 메모 디테일뷰 연결

### DIFF
--- a/MyMemory/MyMemory/View/Detail/DetailViewComponent/ImgDetailView.swift
+++ b/MyMemory/MyMemory/View/Detail/DetailViewComponent/ImgDetailView.swift
@@ -4,13 +4,12 @@
 //
 //  Created by 김성엽 on 1/16/24.
 //
-
 import SwiftUI
 
 struct ImgDetailView: View {
     @Binding var isShownFullScreenCover: Bool
-    @Binding var imagUrl:String
-    @Binding var images: [String]
+    @Binding var selectedImage: Int
+    var images: [Data]
     
     var body: some View {
         
@@ -23,67 +22,25 @@ struct ImgDetailView: View {
                     isShownFullScreenCover.toggle()
                 } label: {
                     Image(systemName: "xmark")
-                        .foregroundStyle(.white)
+                        .foregroundStyle(Color.accentColor)
                         .font(.largeTitle)
                 }
                 .padding(.top, 50)
                 
-                TabView(selection: $imagUrl) {
-                    ForEach(images, id: \.self) { img in
-                        AsyncImage(url: URL(string: img)) { phase in
-                            switch phase {
-                            case .success(let image):
-                                image.imageModifier()
-                            case .failure(_):
-                                VStack {
-                                    Image(systemName: "xmark.circle.fill").iconModifier()
-                                    Text("오류로 이미지를 불러오지 못했습니다")
-                                        .foregroundStyle(.white)
-                                }
-                            case .empty:
-                                Image(systemName: "photo.circle.fill").iconModifier()
-                            @unknown default:
-                                ProgressView()
-                            }
+                TabView(selection: $selectedImage) {
+                    ForEach(images.indices, id: \.self) { index in
+                        if let uiimage = UIImage(data: images[index]) {
+                            Image(uiImage: uiimage)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .padding(.bottom, 50)
                         }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 600)
-                        .padding(.bottom, 50)
                     }
                     
                 }
                 .tabViewStyle(.page)
-                
-                
-                
-                //                    Rectangle()
-                //                        .foregroundStyle(.white)
-                //                        .frame(maxWidth: .infinity)
-                //                        .frame(height: 600)
-                //                        .padding(.bottom, 50)
-                
             }
         }
-    }
-}
-
-//#Preview {
-//    ImgDetailView()
-//}
-
-
-extension Image {
-    func imageModifier() -> some View {
-        self
-            .resizable()
-            .scaledToFit()
-    }
-    
-    func iconModifier() -> some View {
-        self
-            .imageModifier()
-            .frame(maxWidth: 128)
-            .foregroundColor(.purple)
-            .opacity(0.5)
     }
 }

--- a/MyMemory/MyMemory/View/Detail/MemoDetailView.swift
+++ b/MyMemory/MyMemory/View/Detail/MemoDetailView.swift
@@ -8,14 +8,12 @@
 import SwiftUI
 
 struct MemoDetailView: View {
-    @State private var selectedNum: String = ""
+    @State private var selectedNum: Int = 0
     @State private var isHeart: Bool = false
     @State private var isBookmark: Bool = false
     @State private var isShowingSheet: Bool = false
     @State private var isReported: Bool = false
     @State private var isShowingImgSheet: Bool = false
-    @State private var images: [String] = ["https://firebasestorage.googleapis.com:443/v0/b/mymemory-94fc8.appspot.com/o/images%2F02ACAC65-3830-4B43-8EA9-E35AF7B5E184.jpg?alt=media&token=2b6db024-7ed6-4176-a6ad-0955925e906e", "https://firebasestorage.googleapis.com:443/v0/b/mymemory-94fc8.appspot.com/o/images%2F70F144B2-AB09-4A3F-8155-282733613B2D.jpg?alt=media&token=f2cdb0cd-de86-42f6-8cd6-56f7b99896f9", "https://firebasestorage.googleapis.com:443/v0/b/mymemory-94fc8.appspot.com/o/images%2F02ACAC65-3830-4B43-8EA9-E35AF7B5E184.jpg?alt=media&token=2b6db024-7ed6-4176-a6ad-0955925e906e"]
-    
     @State private var isMyMemo:Bool = false
     var memo: Memo
     
@@ -70,6 +68,12 @@ struct MemoDetailView: View {
                                     //.scaledToFit()
                                         .scaledToFill()
                                         .frame(width: 90, height: 90)
+                                        .onTapGesture {
+                                            didTapImage(img: index)
+                                        }
+                                        .fullScreenCover(isPresented: self.$isShowingImgSheet) {
+                                            ImgDetailView(isShownFullScreenCover: self.$isShowingImgSheet, selectedImage: $selectedNum, images: memo.images)
+                                      }
                                 }
                             }
                         }
@@ -117,13 +121,13 @@ struct MemoDetailView: View {
 
 //        .navigationBarItems(
 //            // 오른쪽 부분
-//            trailing:   
+//            trailing:
 //                NavigationBarItems(isHeart: $isHeart, isBookmark: $isBookmark, isShowingSheet: $isShowingSheet, isReported: $isReported, isShowingImgSheet: $isShowingSheet, isMyMemo: $isMyMemo, memo: memo)
 //        )
     }
         
     
-    func didTapImage(img: String) {
+    func didTapImage(img: Int) {
         selectedNum = img
         isShowingImgSheet.toggle()
     }
@@ -133,9 +137,3 @@ struct MemoDetailView: View {
     }
     
 }
-    
-
-//#Preview {
-//    MemoDetailView()
-//}
-


### PR DESCRIPTION
[Refactoring]
- 메모 디테일뷰와 이미지 디테일 뷰를 다시 연결했습니다.  
- incides를 사용하는 foreach 내부에서 다른뷰로 데이터를 바인딩으로 넘겨줄 경우 오류가 발생하고, 해당 오류는 $ 앞에 self. 을 붙여주면 해결되는 것을 확인했습니다. 
- 다만 전부 self를 붙여주지 않아도 오류는 해결되는데, 이건 왜 그런지 잘 모르겠습니다..