### PR TITLE
Refactoring/mypage: 내가 작성한 메모 불러오기 및 리팩토링

### DIFF
--- a/MyMemory/MyMemory/API/MemoService.swift
+++ b/MyMemory/MyMemory/API/MemoService.swift
@@ -225,23 +225,16 @@ struct MemoService {
     }
     
     
-    func fetchMyMemos() async -> [Memo] {
+    func fetchMyMemos(userID: String) async -> [Memo] {
         do {
-            let authResult = try await Auth.auth().signIn(withEmail: "test@test.com", password: "qwer1234!")
-            let userID = authResult.user.uid
-            
-            let querySnapshot = try await COLLECTION_MEMOS.getDocuments()
-            
+            let querySnapshot = try await COLLECTION_MEMOS.whereField("userUid", isEqualTo: userID).getDocuments()
             var memos = [Memo]()
             
             // 모든 메모를 돌면서 현제 로그인 한 사용자의 uid와 작성자 uid가 같은 것만을 추출해 담아 반환
             for document in querySnapshot.documents {
                 let data = document.data()
-                
-                if let userUid = data["userUid"] as? String, userUid == userID {
-                    if let memo = try await fetchMemoFromDocument(documentID: document.documentID, data: data) {
-                        memos.append(memo)
-                    }
+                if let memo = try await fetchMemoFromDocument(documentID: document.documentID, data: data) {
+                    memos.append(memo)
                 }
             }
             

--- a/MyMemory/MyMemory/Model/Memo.swift
+++ b/MyMemory/MyMemory/Model/Memo.swift
@@ -8,7 +8,7 @@
 import Foundation
 import FirebaseFirestore
 import Firebase
-
+import CoreLocation
 
 struct Memo:  Hashable, Codable, Identifiable {
    
@@ -28,5 +28,13 @@ struct Memo:  Hashable, Codable, Identifiable {
 
     var likeCount: Int  // 좋아요 개수
     var memoImageUUIDs: [String]  // 추후 이미지를 Storage에서 지우기 위한 변수입니다.
- 
+}
+
+struct Location: Hashable, Codable {
+    var latitude: Double
+    var longitude: Double
+    func distance(from loc: CLLocation) -> Double {
+        let clloc = CLLocation(latitude: latitude, longitude: longitude)
+        return clloc.distance(from: loc)
+    }
 }

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageView.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageView.swift
@@ -7,6 +7,14 @@
 
 import SwiftUI
 
+enum SortedTypeOfMemo: String, CaseIterable, Identifiable {
+    case last = "최신순"
+    case like = "좋아요순"
+    case close = "가까운순"
+    
+    var id: SortedTypeOfMemo { self }
+}
+
 struct MypageView: View {
     
     let user: User?
@@ -55,7 +63,7 @@ struct MypageView: View {
                                     }
                                 }
                             }
-                            .disabled(!viewModel.isCurrentUserLoginState)
+                            .disabled(!viewModel.user.isCurrentUser)
                         }
                         .padding(.top, 38)
                         
@@ -113,6 +121,11 @@ struct MypageView: View {
             }
  
         }
+        .onAppear(perform: {
+            Task {
+               await viewModel.fetchMyMemoList()
+            }
+        })
 //        .onAppear{
 //            viewModel.
 //        }

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
@@ -6,59 +6,12 @@
 //
 
 import Foundation
-import CoreLocation
 import _PhotosUI_SwiftUI
 import FirebaseAuth
 import FirebaseCore
 import FirebaseFirestore
 
-enum SortedTypeOfMemo: String, CaseIterable, Identifiable {
-    case last = "최신순"
-    case like = "좋아요순"
-    case close = "가까운순"
-    
-    var id: Self { self }
-}
 
-//// 임시
-//struct Memo: Hashable, Codable, Identifiable {
-//    // 유저Id
-//    var userId = UUID()
-//    // 메모 id
-//    var id = UUID()
-//    // 제목
-//    var userUid: String
-//    
-//    var title: String
-//    // 메모 내용
-//    var description: String
-//    // 주소
-//    var address: String
-//    // 태그
-//    var tags: [String]
-//    // 사진
-//    var images: [Data]
-//    // 공개여부
-//    var isPublic: Bool
-//    // 작성일
-//    var date: TimeInterval
-//    // 위치
-//    var location: Location
-//    // 좋아요 개수
-//    var likeCount: Int
-//    
-//    var memoImageUUIDs: [String]
-//    // 추후 이미지를 Storage에서 지우기 위한 변수입니다.
-//}
-
-struct Location: Hashable, Codable {
-    var latitude: Double
-    var longitude: Double
-    func distance(from loc: CLLocation) -> Double {
-        let clloc = CLLocation(latitude: latitude, longitude: longitude)
-        return clloc.distance(from: loc)
-    }
-}
 
 class MypageViewModel: ObservableObject {   
     
@@ -70,6 +23,7 @@ class MypageViewModel: ObservableObject {
     @Published var isCurrentUserLoginState = false
   
     let db = Firestore.firestore()
+    let memoService = MemoService.shared
     
     @Published var user: User
     
@@ -77,13 +31,11 @@ class MypageViewModel: ObservableObject {
         self.user = user
         fetchUserState()
         //self.isCurrentUserLoginState = fetchCurrentUserLoginState()
-        self.memoList = [
-            Memo(userUid: "123", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 - 1300, location: Location(latitude: 37.402101, longitude: 127.108478), likeCount: 10, memoImageUUIDs: [""]),
-            Memo(userUid: "456", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 - 3300, location: Location(latitude: 37.402201, longitude: 127.108578), likeCount: 10, memoImageUUIDs: [""]),
-            Memo(userUid: "789", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 - 100, location: Location(latitude: 37.402301, longitude: 127.108678), likeCount: 10, memoImageUUIDs: [""]),
-            Memo(userUid: "91011", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 + 200, location: Location(latitude: 37.402401, longitude: 127.108778), likeCount: 10, memoImageUUIDs: [""]),
-            Memo(userUid: "1234", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970, location: Location(latitude: 37.402501, longitude: 127.108878), likeCount: 10, memoImageUUIDs: [""]),
-        ]
+        if let userID = self.user.id {
+            Task {
+                self.memoList = await memoService.fetchMyMemos(userID: userID)
+            }
+        }
     }
     
     // MARK: 현재 사용의 위치(위도, 경도)와 메모의 위치, 그리고 설정할 거리를 통해 설정된 거리 내 메모를 필터링하는 함수(CLLocation의 distance 메서드 사용)
@@ -119,7 +71,7 @@ class MypageViewModel: ObservableObject {
         }
     }
     func fetchUserState() {
-        guard let uid = user.id else { return }
+        guard let _ = user.id else { return }
     }
     
     func fetchCurrentUserLoginState() -> Bool {
@@ -142,4 +94,12 @@ class MypageViewModel: ObservableObject {
 //            return nil
 //        }
 //    }
+    
+    func fetchMyMemoList() async {
+        if let userId = self.user.id {
+            self.memoList = await memoService.fetchMyMemos(userID: userId)
+        } else {
+            print("로그인 중이 아닙니다.")
+        }
+    }
 }

--- a/MyMemory/MyMemory/View/Authentication/ProfileEditViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/ProfileEditViewModel.swift
@@ -47,12 +47,12 @@ class ProfileEditViewModel: ObservableObject {
             throw NSError(domain: "Invalid image data", code: 0, userInfo: nil)
         }
         
-        guard let compressedImageData = image.jpegData(compressionQuality: 0.75) else {
+        guard let compressedImageData = image.jpegData(compressionQuality: 0.2) else {
             throw NSError(domain: "Image compression failed.", code: 0, userInfo: nil)
         }
         
         let storageRef = storage.reference()
-        let imageRef = storageRef.child("images/\(UUID().uuidString).jpg")
+        let imageRef = storageRef.child("profile_images/\(UUID().uuidString).jpg")
         let metaData = StorageMetadata()
         metaData.contentType = "image/jpeg"
         


### PR DESCRIPTION
1. 내가 작성한 메모 불러오기 기능을 추가하였습니다.
- MemoService 내 fetchMyMemos 메서드 수정: 기존에 모든 메모를 불러와 유저의 Uid를 비교하여 맞는 메모만 배열에 추가하
던 로직을 whereField 메서드를 사용하여 대체하였습니다
- 임시로 사용하던 userID를 파라미터로 변경하여 사용하는 곳에서 넘겨주도록 변경하였습니다.
- 마이페이지에 접근할 경우 메모들이 최신화됩니다.
- 기존에 사용되던 로직을 제거했습니다.
2. 프로필 사진이 불러와지지 않는 에러를 수정하였습니다. 
- 사진저장, 불러오는 위치를 images -> profile_images로 변경하였습니다.
- 프로필 사진변경 시 이미지 압축률을 높였습니다. (0.75 -> 0.2)
3. Memo.swift 파일로 Location 구조체를 이동하였습니다.