### PR TITLE
[Add] 애플 로그인 성공 후 맵뷰로 연결

### DIFF
--- a/MyMemory/MyMemory/View/Authentication/LoginView.swift
+++ b/MyMemory/MyMemory/View/Authentication/LoginView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import FirebaseAuth
-
+import AuthenticationServices
 
 struct LoginView: View {
     
@@ -136,7 +136,40 @@ struct LoginView: View {
             
             // MARK: - 소셜 로그인 버튼
             VStack {
-                AppleSigninButton()
+                SignInWithAppleButton(
+                    onRequest: { request in
+                        print("working")
+                        viewModel.nonce = viewModel.randomNonceString()
+                        request.requestedScopes = [.fullName, .email]
+                        request.nonce = viewModel.sha256(viewModel.nonce)
+                    },
+                    onCompletion: { result in
+                        switch result {
+                        case .success(let authResults):
+                            print("Apple Login Successful")
+                            guard let credential = authResults.credential as? ASAuthorizationAppleIDCredential else {
+                                print("error with firebase")
+                                return
+                            }
+                            switch authResults.credential {
+                                case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                                let fullName = appleIDCredential.fullName
+                                self.viewModel.name = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+                                self.viewModel.email = appleIDCredential.email ?? "emailnotfound"
+                            default:
+                                break
+                            }
+                            self.viewModel.authenticate(credential: credential)
+                            self.isActive = true
+                            presentationMode.wrappedValue.dismiss()
+                        case .failure(let error):
+                            print(error.localizedDescription)
+                            print("error")
+                        }
+                    }
+                )
+                .frame(width : 350, height:50)
+                .cornerRadius(10)
                 Button {
                     
                 } label: {

--- a/MyMemory/MyMemory/View/Authentication/LoginViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/LoginViewModel.swift
@@ -66,44 +66,44 @@ struct SocialLoginButton: ButtonStyle {
   }
 }
 
-struct AppleSigninButton : View{
-    
-    @State var currentNounce: String?
-    @ObservedObject var appleLoginData: AuthViewModel = AuthViewModel()
-    
-    var body: some View{
-        
-        SignInWithAppleButton(
-            onRequest: { request in
-                print("working")
-                appleLoginData.nonce = appleLoginData.randomNonceString()
-                request.requestedScopes = [.fullName, .email]
-                request.nonce = appleLoginData.sha256(appleLoginData.nonce)
-            },
-            onCompletion: { result in
-                switch result {
-                case .success(let authResults):
-                    print("Apple Login Successful")
-                    guard let credential = authResults.credential as? ASAuthorizationAppleIDCredential else {
-                        print("error with firebase")
-                        return
-                    }
-                    switch authResults.credential {
-                        case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                        let fullName = appleIDCredential.fullName
-                        self.appleLoginData.name = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-                        self.appleLoginData.email = appleIDCredential.email ?? "emailnotfound"
-                    default:
-                        break
-                    }
-                    self.appleLoginData.authenticate(credential: credential)
-                case .failure(let error):
-                    print(error.localizedDescription)
-                    print("error")
-                }
-            }
-        )
-        .frame(width : 350, height:50)
-        .cornerRadius(10)
-    }
-}
+//struct AppleSigninButton : View{
+//    
+//    @State var currentNounce: String?
+//    @ObservedObject var appleLoginData: AuthViewModel = AuthViewModel()
+//    
+//    var body: some View{
+//        
+//        SignInWithAppleButton(
+//            onRequest: { request in
+//                print("working")
+//                appleLoginData.nonce = appleLoginData.randomNonceString()
+//                request.requestedScopes = [.fullName, .email]
+//                request.nonce = appleLoginData.sha256(appleLoginData.nonce)
+//            },
+//            onCompletion: { result in
+//                switch result {
+//                case .success(let authResults):
+//                    print("Apple Login Successful")
+//                    guard let credential = authResults.credential as? ASAuthorizationAppleIDCredential else {
+//                        print("error with firebase")
+//                        return
+//                    }
+//                    switch authResults.credential {
+//                        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+//                        let fullName = appleIDCredential.fullName
+//                        self.appleLoginData.name = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+//                        self.appleLoginData.email = appleIDCredential.email ?? "emailnotfound"
+//                    default:
+//                        break
+//                    }
+//                    self.appleLoginData.authenticate(credential: credential)
+//                case .failure(let error):
+//                    print(error.localizedDescription)
+//                    print("error")
+//                }
+//            }
+//        )
+//        .frame(width : 350, height:50)
+//        .cornerRadius(10)
+//    }
+//}


### PR DESCRIPTION
[Add]

* 올려주신 로그인버튼과 뷰연결을 이용해서 애플로그인 성공시 메인맵뷰로 이동하게 해놨습니다.

------------------------------------------------
특이사항

* 현재있는 애플로그인 탭 문제는 .onTapGesture 함수때문인것으로 확인되었습니다. SignInWithAppleButton()을 감싸고있는 VStack이나  상단뷰에서 .onTapGesture를 사용할경우, 애플로그인 버튼이 싱글탭(한손가락 한번 탭)동작에는 반응을 안하고있는데, 관련된사항은 일단 더 찾아보고, 아예그냥 커스텀으로 만들던지 하겠습니다.

* 원래는 애플로그인 버튼을 AppleSigninButton 이라는 뷰에서 관리하고 있었는데, 뷰 연결하면서 테스트 겸 LoginView에 꺼내놓았습니다. 일단 당장 내일이 발표인데 뷰 연결이 작동되는것을 확인하여 먼저 머지를 하고,  후에 깔끔하게 다시 정리하도록하겠습니다