### PR TITLE
Fix: AuthViewModel 내 FetchUser() 무한 호출 이슈

### DIFF
--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageTopView.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageTopView.swift
@@ -14,7 +14,7 @@ struct MypageTopView: View {
     
     var body: some View {
         HStack {
-            if authViewModel.currentUser != nil {
+            if authViewModel.currentUser != nil && UserDefaults.standard.string(forKey: "userId") != nil {
                 NavigationLink {
                     ProfileEditView(
                         existingProfileImage:

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageView.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageView.swift
@@ -20,10 +20,10 @@ enum SortedTypeOfMemo: String, CaseIterable, Identifiable {
 struct MypageView: View {
     @Binding var selected: Int
     @ObservedObject var viewModel: MypageViewModel = .init()
-    @ObservedObject var authViewModel: AuthViewModel = .shared
     @State var presentLoginAlert: Bool = false
     @State var presentLoginView: Bool = false
-
+    @ObservedObject var authViewModel: AuthViewModel = .shared
+    
     var body: some View {
         ZStack(alignment: .top) {
             
@@ -36,8 +36,7 @@ struct MypageView: View {
                     
                     MypageTopView(viewModel: viewModel)
                     
-                    
-                    if authViewModel.currentUser != nil {
+                      if authViewModel.currentUser != nil && UserDefaults.standard.string(forKey: "userId") != nil  {
                         
                         HStack(alignment: .lastTextBaseline) {
                             Text("내가 작성한 메모")
@@ -59,7 +58,7 @@ struct MypageView: View {
                                     }
                                 }
                             }
-                            .disabled(!(AuthViewModel.shared.userSession?.uid == UserDefaults.standard.string(forKey: "userId") ))
+                            .disabled(!(authViewModel.userSession?.uid == UserDefaults.standard.string(forKey: "userId") ))
                         }
                         .padding(.top, 38)
                         
@@ -112,7 +111,7 @@ struct MypageView: View {
         .onAppear(perform: {
             
             Task {
-                if let id = UserDefaults.standard.string(forKey: "userId") {
+                if UserDefaults.standard.string(forKey: "userId") != nil {
                     presentLoginAlert = false
                     await viewModel.fetchMyMemoList()
                 } else {

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
@@ -22,9 +22,9 @@ class MypageViewModel: ObservableObject {
     @Published var selectedPhotoData: Data? = nil
     @Published var isCurrentUserLoginState = false
 
-    let db = Firestore.firestore()
+  //  let db = Firestore.firestore()
     let memoService = MemoService.shared
-    @Published var user: User? 
+    @Published var user: User?
     
     init() {
         fetchUserState()
@@ -36,9 +36,11 @@ class MypageViewModel: ObservableObject {
                 self.memoList = await self.memoService.fetchMyMemos(userID: userID)
             }
         }
-        AuthViewModel.shared.fetchUser()
-
         let user = AuthViewModel.shared.currentUser
+        AuthViewModel.shared.fetchUser()
+//        AuthViewModel.shared.fetchUser()
+
+        
     }
     
     // MARK: 현재 사용의 위치(위도, 경도)와 메모의 위치, 그리고 설정할 거리를 통해 설정된 거리 내 메모를 필터링하는 함수(CLLocation의 distance 메서드 사용)

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
@@ -24,7 +24,8 @@ class MypageViewModel: ObservableObject {
 
     let db = Firestore.firestore()
     let memoService = MemoService.shared
-    @Published var user: User? = nil
+    @Published var user: User? 
+    
     init() {
         fetchUserState()
         //self.isCurrentUserLoginState = fetchCurrentUserLoginState()
@@ -32,7 +33,7 @@ class MypageViewModel: ObservableObject {
         if let userID = UserDefaults.standard.string(forKey: "userId") {
             Task {[weak self] in
                 guard let self = self else {return}
-//                self.memoList = await self.memoService.fetchMyMemos(userID: userID)
+                self.memoList = await self.memoService.fetchMyMemos(userID: userID)
             }
         }
         AuthViewModel.shared.fetchUser()

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageViewModel.swift
@@ -36,9 +36,9 @@ class MypageViewModel: ObservableObject {
                 self.memoList = await self.memoService.fetchMyMemos(userID: userID)
             }
         }
-        let user = AuthViewModel.shared.currentUser
+        user = AuthViewModel.shared.currentUser
         AuthViewModel.shared.fetchUser()
-//        AuthViewModel.shared.fetchUser()
+
 
         
     }

--- a/MyMemory/MyMemory/View/Main/MainTabView.swift
+++ b/MyMemory/MyMemory/View/Main/MainTabView.swift
@@ -12,10 +12,6 @@ struct MainTabView: View {
     
 //    @ObservedObject var viewRouter: ViewRouter
     @State private var selectedIndex = 0
-    @EnvironmentObject var viewModel : AuthViewModel
-    @State var isPresented: Bool = false
- 
-    @State var isLogin: Bool = false
  
     var body: some View {
         
@@ -30,8 +26,8 @@ struct MainTabView: View {
                         Image(systemName: "map.fill")
                         Text("지도")
                     }.tag(0)
+                
                 PostView(selected: $selectedIndex)
-//                Text("")
                     .onTapGesture {
                         selectedIndex = 1
                     }
@@ -40,6 +36,7 @@ struct MainTabView: View {
                         Text("메모하기")
                     }
                     .tag(1)
+                
                 MypageView(selected: $selectedIndex)
                     .onTapGesture{
                         selectedIndex = 2
@@ -49,56 +46,7 @@ struct MainTabView: View {
                         Text("마이")
                     }
                     .tag(2)
-//                // 로그인한 유저 확인
-//                if viewModel.userSession != nil {
-//                    if let user = viewModel.currentUser {
-//                        
-//                   }
-//                } 
-//                // 로그아웃 상태일 때,
-//                else {
-//                    
-//                    Text("로그인이 필요합니다.")
-//                        .onTapGesture{
-//                            selectedIndex = 2
-//                              isLogin = true
-//                        }
-//                        .tabItem {
-//                            Image(systemName: "person")
-//                            Text("마이")
-//                        }
-//                        .tag(2)
-//                    
-//                }
             }
-            // PostView는 Tab전환 대신 Navigation으로 이동
-//            .onChange(of: selectedIndex) { [selectedIndex] newTab in
-//                if newTab == 1 {
-//                    self.selectedIndex = selectedIndex
-//                    isPresented = true
-//                    isLogin = false
-//                    
-//                }
-//                if newTab == 2 && viewModel.userSession == nil {
-//                    self.selectedIndex = selectedIndex
-//                    isLogin = true
-//                    isPresented = false
-//                    
-//                }
-//            }
-//            // NavigationView - LoginView
-//            .background(
-//                
-//                NavigationLink(
-//                    destination: LoginView(),
-//                    isActive: $isLogin
-//                ) {
-//                    EmptyView()
-//                }
-//                    .hidden()
-//                
-//            )
- 
         }
       
     }

--- a/MyMemory/MyMemory/View/Setting/SettingView.swift
+++ b/MyMemory/MyMemory/View/Setting/SettingView.swift
@@ -72,17 +72,21 @@ struct SettingView: View {
                             .background(.blue)
                             .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
-                    .alert("로그아웃 하시겠습니까?", isPresented: $settingViewModel.isShowingLogoutAlert) {
+                    .alert("로그아웃 하시겠습니까?", 
+                           isPresented: $settingViewModel.isShowingLogoutAlert) {
+                        
                         Button("로그아웃", role: .destructive) {
-                                                   if authViewModel.signout() {
-                            print("로그아웃 성공")
-                                                       
-                                                       UserDefaults.standard.removeObject(forKey: "userId")
-                            presentationMode.wrappedValue.dismiss()
-                        } else {
-                            print("로그아웃 실패")
+                                                   
+                            if authViewModel.signout() {
+                            
+                                print("로그아웃 성공")
+                                UserDefaults.standard.removeObject(forKey: "userId")
+                                presentationMode.wrappedValue.dismiss()
+                            } else {
+                                print("로그아웃 실패")
+                            }
                         }
-                        }
+                        
                         Button("뒤로가기", role: .cancel) {}
                     }
                     

--- a/MyMemory/MyMemory/ViewModel/Authentication/AuthViewModel.swift
+++ b/MyMemory/MyMemory/ViewModel/Authentication/AuthViewModel.swift
@@ -54,18 +54,6 @@ class AuthViewModel: ObservableObject {
         fetchUser()
     }
     
-//    func login(withEmail email: String, password: String)   {
-//        Auth.auth().signIn(withEmail: email, password: password) { result, error in
-//            if let error = error {
-//                print("디버깅: 로그인실패 \(error.localizedDescription)")
-//                return
-//            }
-//            guard let user = result?.user else { return }
-//            self.userSession = user
-//            
-//            self.fetchUser()
-//        }
-//    }
     func login(withEmail email: String, password: String) -> Bool {
         do {
             try Auth.auth().signIn(withEmail: email, password: password) { result, error in
@@ -204,7 +192,7 @@ class AuthViewModel: ObservableObject {
             
             self?.currentUser = user
             UserDefaults.standard.set(user.id, forKey: "userId")
-            print(user)
+           // print(user)
         }
     }
     func authenticate(credential: ASAuthorizationAppleIDCredential) {
@@ -251,7 +239,7 @@ class AuthViewModel: ObservableObject {
             
             self?.currentUser = user
             UserDefaults.standard.set(user.id, forKey: "userId")
-            print(user)
+          //  print(user)
         }
     }
     

--- a/MyMemory/MyMemory/ViewModel/Authentication/AuthViewModel.swift
+++ b/MyMemory/MyMemory/ViewModel/Authentication/AuthViewModel.swift
@@ -77,6 +77,8 @@ class AuthViewModel: ObservableObject {
         self.userSession = nil
         do {
             try Auth.auth().signOut()
+            
+            self.fetchUser()
             return true
         } catch {
             return false


### PR DESCRIPTION
## #100 **Fix: AuthViewModel 내 FetchUser() 무한 호출 이슈** 


<img width="380" alt="스크린샷 2024-01-24 오후 3 51 42" src="https://github.com/APP-iOS3rd/PJ3T2_Mymory/assets/75136643/6dd0d8bc-88dc-4f41-bb7a-ec73fdc94a9c">

로그인 후, 어느 뷰를 가든 무한 호출되고 있습니다.

```swift
@EnvironmentObject var viewModel : AuthViewModel
```
해당 코드를 주석처리하여 해당 문제를 해결했습니다.

## #99 **로그인/로그아웃 후, 마이페이지 정보가 바로 업데이트 되지 않는 현상**

### 1. 로그인 후, 유저정보는 노출되나 메모리스트가 노출되지 않는 현상

### 2. 로그인 했는데, 유저 상태가 초기화 되는 현상
```swift
 //  @Published var user: User? = nil // 이전 코드 
@Published var user: User?

```
로그인을 했으나, 유저 정보가 없어져서 다시 로그인하라는 alert가 나오는 문제가 있었습니다. 해당 부분은 nil 제거 하여 이슈를 해결했습니다.



### 3. 로그아웃 후 유저정보, 메모리스트가 그대로 남아있는 현상

로그아웃 직후, 유저 정보와 메모리스트가 어느 뷰를 다녀왔어도 지워지지 않고 그대로 남아있는 문제가 있었습니다. 

```swift
// if authViewModel.currentUser != nil {

if authViewModel.currentUser != nil 
&& UserDefaults.standard.string(forKey: "userId") != nil {

```

해당 부분은 UserDefaults 코드가 추가되지 않아서 생긴 이슈로, MypageTopView, MypageView 파일에 해당 코드를 수정했습니다.


<img  src="https://github.com/APP-iOS3rd/PJ3T2_Mymory/assets/75136643/733616c0-52da-4d92-854f-5bf646a992fa" width="400"/>






