### PR TITLE
[Feat]: MemoDetail뷰 양 옆으로 넘기기 구현

### DIFF
--- a/MyMemory/MyMemory.xcodeproj/project.pbxproj
+++ b/MyMemory/MyMemory.xcodeproj/project.pbxproj
@@ -1261,7 +1261,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.likelion.MyMemory;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.likelion.MyMemory";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = MyMemoryDev;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1314,7 +1314,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.likelion.MyMemory;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.likelion.MyMemory";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = MyMemoryDist;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/MyMemory/MyMemory/Source/Components/Memo/MemoCell.swift
+++ b/MyMemory/MyMemory/Source/Components/Memo/MemoCell.swift
@@ -14,8 +14,9 @@ struct MemoCell: View {
     @State var isDark: Bool = false
     @Binding var location: CLLocation?
     @EnvironmentObject var mainMapViewModel: MainMapViewModel
-    
+    @State var selectedMemoIndex: Int = 0
     @State var memo: Memo = Memo(userUid: "123", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 - 1300, location: Location(latitude: 0, longitude: 0), likeCount: 10, memoImageUUIDs: [""])
+    @State var memos: [Memo] = [Memo(userUid: "123", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 - 1300, location: Location(latitude: 0, longitude: 0), likeCount: 10, memoImageUUIDs: [""])]
     
     @State var likeCount = 0
     
@@ -112,7 +113,7 @@ struct MemoCell: View {
                     
                     
                     NavigationLink { // 버튼이랑 비슷함
-                        DetailView(memo: $memo, isVisble: $isVisible)
+                        DetailView(memo: $memo, isVisble: $isVisible, location: $location, memos: $memos, selectedMemoIndex: $selectedMemoIndex)
                         
                     } label: {
                         HStack {
@@ -138,7 +139,7 @@ struct MemoCell: View {
         .cornerRadius(20)
         .onAppear {
             if let distance = location?.coordinate.distance(from: memo.location) {
-                if distance <= 5 {
+                if distance <= 100 {
                     isVisible = true
                 } else {
                     isVisible = false
@@ -152,7 +153,7 @@ struct MemoCell: View {
         }
         .onChange(of: location) { Value in
             if let distance = Value?.coordinate.distance(from: memo.location) {
-                if distance <= 50 {
+                if distance <= 100 {
                     isVisible = true
                 } else {
                     isVisible = false

--- a/MyMemory/MyMemory/Source/Shared/PushNotification.swift
+++ b/MyMemory/MyMemory/Source/Shared/PushNotification.swift
@@ -12,4 +12,5 @@ import SwiftUI
 final class PushNotification: ObservableObject {
     static let shared = PushNotification()
     @Published var memo: Memo? = nil
+    @Published var memos: [Memo]? = nil
 }

--- a/MyMemory/MyMemory/Source/Shared/PushNotification.swift
+++ b/MyMemory/MyMemory/Source/Shared/PushNotification.swift
@@ -12,5 +12,4 @@ import SwiftUI
 final class PushNotification: ObservableObject {
     static let shared = PushNotification()
     @Published var memo: Memo? = nil
-    @Published var memos: [Memo]? = nil
 }

--- a/MyMemory/MyMemory/View/Authentication/Mypage/MypageMemoList.swift
+++ b/MyMemory/MyMemory/View/Authentication/Mypage/MypageMemoList.swift
@@ -13,9 +13,9 @@ struct MypageMemoList: View {
     
     var body: some View {
         LazyVStack(spacing: 12) {
-            ForEach($viewModel.memoList, id: \.self) { memo in
+            ForEach(Array(zip($viewModel.memoList.indices, $viewModel.memoList)), id: \.0) { index, memo in
                 NavigationLink {
-                    MemoDetailView(memo: memo)
+                    MemoDetailView(memo: memo, memos: viewModel.memoList, location: $viewModel.currentLocation, selectedMemoIndex: index)
                     
                 } label: {
                     MypageMemoListCell(

--- a/MyMemory/MyMemory/View/Detail/DetailView.swift
+++ b/MyMemory/MyMemory/View/Detail/DetailView.swift
@@ -6,14 +6,18 @@
 //
 
 import SwiftUI
+import CoreLocation
 
 struct DetailView: View {
     @Binding var memo: Memo
     @Binding var isVisble: Bool
+    @Binding var location: CLLocation?
+    @Binding var memos: [Memo]
+    @Binding var selectedMemoIndex: Int
     
     var body: some View {
         if isVisble {
-            MemoDetailView(memo: $memo)
+            MemoDetailView(memo: $memo, memos: memos, location: $location, selectedMemoIndex: selectedMemoIndex)
         } else {
             CertificationView(memo: $memo)
         }

--- a/MyMemory/MyMemory/View/Detail/MemoDetailView.swift
+++ b/MyMemory/MyMemory/View/Detail/MemoDetailView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Kingfisher
+import CoreLocation
+
 struct MemoDetailView: View {
     @State private var selectedNum: Int = 0
     @State private var isHeart: Bool = false
@@ -9,103 +11,132 @@ struct MemoDetailView: View {
     @State private var isShowingImgSheet: Bool = false
     @State private var isMyMemo:Bool = false
     @Binding var memo: Memo
+    @State var memos: [Memo] = [Memo(userUid: "123", title: "ggg", description: "gggg", address: "서울시 @@구 @@동", tags: ["ggg", "Ggggg"], images: [], isPublic: false, date: Date().timeIntervalSince1970 - 1300, location: Location(latitude: 0, longitude: 0), likeCount: 10, memoImageUUIDs: [""])]
+    @Binding var location: CLLocation?
+    @State var selectedMemoIndex = 0
     
     @StateObject var viewModel: DetailViewModel = DetailViewModel()
     
     var body: some View {
         ZStack {
-       
-            ScrollView {
-                VStack(alignment: .leading) {
-                    ScrollView(.horizontal) {
-                        LazyHGrid(rows: [.init(.flexible())], spacing: 5) {
-                            ForEach(memo.tags, id: \.self) { tag in
-                                Text("#\(tag)")
-                                    .font(.semibold12)
-                                    .padding(.horizontal, 13)
-                                    .padding(.vertical, 6)
-                                    .foregroundColor(.textColor)
-                                    .background(
-                                        Capsule()
-                                            .foregroundColor(.peach)
-                                    )
-                                
+            TabView(selection: $selectedMemoIndex) {
+                ForEach(Array(zip(memos.indices, memos)), id: \.0) { index, memo in
+                    if let loc = location?.coordinate.distance(from: memo.location) {
+                        if loc > 100 && !isMyMemo{
+                            VStack {
+                                Image(systemName: "lock")
+                                    .font(.largeTitle)
+                                    .foregroundColor(.gray)
+                                    .padding()
+                                Text("해당 메모는 거리가 멀어서 볼 수 없어요.")
+                                    .font(.regular18)
                             }
-                        }
-                    }.frame(maxWidth: .infinity)
-                        .aspectRatio(contentMode: .fit)
-                        .padding(.leading, 25)
-                    
-                    
-                    HStack{
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(memo.title)
-                                .font(.bold20)
-                            Text(memo.address)
-                                .font(.regular14)
-                                .foregroundStyle(Color.textGray)
-                            
-                            Text("등록 수정일 : \(memo.date.createdAtTimeYYMMDD)")
-                                .font(.regular14)
-                                .foregroundStyle(Color.textGray)
-                        }
-                        Spacer()
-                    }.padding(.leading, 25)
-                    
-                    
-                    
-                    
-                    ScrollView(.horizontal) {
-                        HStack{
-                            ForEach(memo.images.indices, id: \.self) { index in
-                                if let uiimage =  UIImage(data: memo.images[index]) {
-                                    Image(uiImage: uiimage)
-                                        .resizable()
-                                    //.scaledToFit()
-                                        .scaledToFill()
-                                        .frame(width: 90, height: 90)
-                                        .onTapGesture {
-                                            didTapImage(img: index)
+                        } else {
+                            VStack {
+                                ScrollView {
+                                VStack(alignment: .leading) {
+                                    ScrollView(.horizontal) {
+                                        LazyHGrid(rows: [.init(.flexible())], spacing: 5) {
+                                            ForEach(memo.tags, id: \.self) { tag in
+                                                Text("#\(tag)")
+                                                    .font(.semibold12)
+                                                    .padding(.horizontal, 13)
+                                                    .padding(.vertical, 6)
+                                                    .foregroundColor(.textColor)
+                                                    .background(
+                                                        Capsule()
+                                                            .foregroundColor(.peach)
+                                                    )
+                                                
+                                            }
                                         }
-                                        .fullScreenCover(isPresented: self.$isShowingImgSheet) {
-                                            ImgDetailView(isShownFullScreenCover: self.$isShowingImgSheet, selectedImage: $selectedNum, images: memo.images)
-                                      }
+                                    }.frame(maxWidth: .infinity)
+                                        .aspectRatio(contentMode: .fit)
+                                        .padding(.leading, 25)
+                                    
+                                    
+                                    HStack{
+                                        VStack(alignment: .leading, spacing: 6) {
+                                            Text(memo.title)
+                                                .font(.bold20)
+                                            Text(memo.address)
+                                                .font(.regular14)
+                                                .foregroundStyle(Color.textGray)
+                                            
+                                            Text("등록 수정일 : \(memo.date.createdAtTimeYYMMDD)")
+                                                .font(.regular14)
+                                                .foregroundStyle(Color.textGray)
+                                        }
+                                        Spacer()
+                                    }.padding(.leading, 25)
+                                
+                                    ScrollView(.horizontal) {
+                                        HStack{
+                                            ForEach(memo.images.indices, id: \.self) { index in
+                                                if let uiimage =  UIImage(data: memo.images[index]) {
+                                                    Image(uiImage: uiimage)
+                                                        .resizable()
+                                                    //.scaledToFit()
+                                                        .scaledToFill()
+                                                        .frame(width: 90, height: 90)
+                                                        .onTapGesture {
+                                                            didTapImage(img: index)
+                                                        }
+                                                        .fullScreenCover(isPresented: self.$isShowingImgSheet) {
+                                                            ImgDetailView(isShownFullScreenCover: self.$isShowingImgSheet, selectedImage: $selectedNum, images: memo.images)
+                                                      }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    .padding(.top, 25)
+                                    .padding(.leading, 25)
+                                    
+                                    Text(memo.description)
+                                        .multilineTextAlignment(.leading)
+                                        .padding(.top, 25)
+
+                                        .padding(.horizontal, 25)
+                                        .padding(.bottom, 70)
+                                    Spacer()
                                 }
+                                //.padding(.top, 50)
+                   
+                            }
+                                .onAppear {
+                                    Task {
+                                        do {
+                                            isMyMemo = try await MemoService().checkMyMemo(checkMemo: memo)
+                                            viewModel.fetchMemoCreator(uid: memo.userUid)
+                                        } catch {
+                                            // 에러 처리
+                                            print("Error checking my memo: \(error.localizedDescription)")
+                                        }
+                                    }
+                                }
+                            
+                            
+                                Spacer()
+                                MoveUserProfileButton(viewModel: viewModel)
                             }
                         }
                     }
-                    .padding(.top, 25)
-                    .padding(.leading, 25)
-                    
-                    Text(memo.description)
-                        .multilineTextAlignment(.leading)
-                        .padding(.top, 25)
+                }//foreach
+            }//: tabview
+            .tabViewStyle(.page(indexDisplayMode: .never))
+        } // :zstack
+//        .onAppear {
+//            Task {
+//                do {
+//                    isMyMemo = try await MemoService().checkMyMemo(checkMemo: memo)
+//                    //viewModel.fetchMemoCreator(uid: memo.userUid)
+//                } catch {
+//                    // 에러 처리
+//                    print("Error checking my memo: \(error.localizedDescription)")
+//                }
+//            }
+//        }
 
-                        .padding(.horizontal, 25)
-                        .padding(.bottom, 70)
-                    Spacer()
-                }
-                //.padding(.top, 50)
-   
-            }
-
-            .onAppear {
-                Task {
-                    do {
-                        isMyMemo = try await MemoService().checkMyMemo(checkMemo: memo)
-                        viewModel.fetchMemoCreator(uid: memo.userUid)
-                    } catch {
-                        // 에러 처리
-                        print("Error checking my memo: \(error.localizedDescription)")
-                    }
-                }
-            }
-            VStack {
-                Spacer()
-                MoveUserProfileButton(viewModel: viewModel)
-            }
-        }
-        
         .customNavigationBar(
             centerView: {
                 Text(" ")
@@ -115,16 +146,9 @@ struct MemoDetailView: View {
             },
             rightView: {
                 NavigationBarItems(isHeart: $isHeart, isBookmark: $isBookmark, isShowingSheet: $isShowingSheet, isReported: $isReported, isShowingImgSheet: $isShowingSheet, isMyMemo: $isMyMemo, memo: $memo)
-//                                        CloseButton()
             },
             backgroundColor: .bgColor
         )
-
-//        .navigationBarItems(
-//            // 오른쪽 부분
-//            trailing:
-//                NavigationBarItems(isHeart: $isHeart, isBookmark: $isBookmark, isShowingSheet: $isShowingSheet, isReported: $isReported, isShowingImgSheet: $isShowingSheet, isMyMemo: $isMyMemo, memo: memo)
-//        )
     }
         
     

--- a/MyMemory/MyMemory/View/Detail/MemoDetailView.swift
+++ b/MyMemory/MyMemory/View/Detail/MemoDetailView.swift
@@ -21,17 +21,17 @@ struct MemoDetailView: View {
         ZStack {
             TabView(selection: $selectedMemoIndex) {
                 ForEach(Array(zip(memos.indices, memos)), id: \.0) { index, memo in
-                    if let loc = location?.coordinate.distance(from: memo.location) {
-                        if loc > 100 && !isMyMemo{
-                            VStack {
-                                Image(systemName: "lock")
-                                    .font(.largeTitle)
-                                    .foregroundColor(.gray)
-                                    .padding()
-                                Text("해당 메모는 거리가 멀어서 볼 수 없어요.")
-                                    .font(.regular18)
-                            }
-                        } else {
+                    // if let loc = location?.coordinate.distance(from: memo.location) {
+                    //     if loc > 100 && !isMyMemo{
+                    //         VStack {
+                    //             Image(systemName: "lock")
+                    //                 .font(.largeTitle)
+                    //                 .foregroundColor(.gray)
+                    //                 .padding()
+                    //             Text("해당 메모는 거리가 멀어서 볼 수 없어요.")
+                    //                 .font(.regular18)
+                    //         }
+                    //     } else {
                             VStack {
                                 ScrollView {
                                 VStack(alignment: .leading) {
@@ -118,8 +118,8 @@ struct MemoDetailView: View {
                             
                                 Spacer()
                                 MoveUserProfileButton(viewModel: viewModel)
-                            }
-                        }
+                            //}
+                       // }
                     }
                 }//foreach
             }//: tabview

--- a/MyMemory/MyMemory/View/Map/MainMapView.swift
+++ b/MyMemory/MyMemory/View/Map/MainMapView.swift
@@ -106,14 +106,17 @@ struct MainMapView: View {
                 //선택한 경우
                 ScrollView(.horizontal) {
                     HStack(spacing: 20) {
-                        ForEach(mainMapViewModel.filterList.isEmpty ? mainMapViewModel.memoList : mainMapViewModel.filteredMemoList) { item  in
+                        ForEach(mainMapViewModel.filterList.isEmpty ? Array(zip(mainMapViewModel.memoList.indices, mainMapViewModel.memoList)) : Array(zip(mainMapViewModel.filteredMemoList.indices, mainMapViewModel.filteredMemoList)), id: \.0) { index, item  in
                             VStack{
                                 Text("\(String(item.didLike))")
                                 MemoCell(
                                     isVisible: true,
                                     isDark: true,
                                     location: $mainMapViewModel.location,
-                                    memo: item)
+                                    selectedMemoIndex: index,
+                                    memo: item,
+                                    memos: mainMapViewModel.filterList.isEmpty ? mainMapViewModel.memoList : mainMapViewModel.filteredMemoList
+                                )
                                 .environmentObject(mainMapViewModel)
                                 .onTapGesture {
                                     mainMapViewModel.memoDidSelect(memo: item)
@@ -146,7 +149,7 @@ struct MainMapView: View {
         .navigationDestination(item:$noti.memo,
                                destination: {memo in
             
-            MemoDetailView(memo: .constant(memo))
+            MemoDetailView(memo: .constant(memo), location: $mainMapViewModel.location)
             
         })
         .moahAlert(isPresented: $showingAlert, moahAlert: {

--- a/MyMemory/MyMemory/View/Map/MemoListView.swift
+++ b/MyMemory/MyMemory/View/Map/MemoListView.swift
@@ -49,13 +49,16 @@ struct MemoListView: View {
                     ScrollView(.vertical, showsIndicators: false){
                         
                         VStack(spacing: 12) {
-                            ForEach(viewModel.filterList.isEmpty ? viewModel.memoList : viewModel.filteredMemoList) { item in
-                                
+                            
+                            ForEach(viewModel.filterList.isEmpty ? Array(zip(viewModel.memoList.indices, viewModel.memoList)) : Array(zip(viewModel.filteredMemoList.indices, viewModel.filteredMemoList)), id: \.0) { index, item  in
                                 MemoCell(
                                     isVisible: true,
-                                    isDark: false,
-                                    location: $viewModel.location,
-                                    memo: item)
+                                     isDark: true,
+                                     location: $viewModel.location,
+                                     selectedMemoIndex: index,
+                                     memo: item,
+                                     memos: viewModel.filterList.isEmpty ? viewModel.memoList : viewModel.filteredMemoList
+                                )
                             }
                             
                         }


### PR DESCRIPTION
# PR 가이드라인
## PR Checklist
PR 날릴 때 체크 리스트

- [x] 코드 컨벤션을 잘 지키셨나요?
- [x] 이슈 체크리스트를 잘 반영했나요?
- [x] Conflict 문제가 발생하지는 않나요?

## PR Type
어떤 종류의 PR인가요?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [x] 새 기능 개발
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 문서 작업 변경
- [ ] 기타 작업

## 연관되는 issue 정보를 알려주세요

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# PR 설명하기
이 PR에 대해 간략하게 소개해주세요!
- 해당 메모와 메모의 배열을 받아 TabView에 전달합니다. 양 옆으로 넘기면서 볼 수 있습니다. 

## 어떻게 작동하나요? code 기반으로 설명해주세요
```swift
 ForEach(Array(zip(memos.indices, memos)), id: \.0) { index, memo in
}
```
- foreach를 사용하며 index도 사용하기 위해 Array(zip () ) 으로 묶었습니다. 각 메모는 `id: \.0`로 인해 Int 값을 id로 가지며, 이 인덱스값을 selection으로 전달합니다.
- 해당 로직을 사용하기 위해 MemoCell과 MemoDetailView에 접근하는 모든 뷰의 foreach문을 변경했습니다. 혹시 충돌이 확인된다면 바로 이야기 해주세요.
---

## 변경 사항 스크린샷 혹은 화면 녹화

![Feb-01-2024 16-52-58](https://github.com/APP-iOS3rd/PJ3T2_Mymory/assets/144765545/943005d0-ef26-40b3-875b-2619c0237009)



## 기타 언급해야 할 사항들

- 넘어갈 때 좀 버벅이는 현상이 있습니다. 최적화를 하거나 TabView 이외의 다른 방법을 찾아야할 거 같습니다.
- TabView의 화면이 넘어갈때 유저 정보를 받아오는데, 화면이 조금만 넘어가도 아래의  MoveUserProfileButton(viewModel: viewModel) 으로 구현된 부분이 변경됩니다. 

- 이 두 가지 현상은 아마 슬라이드가 아닌 버튼으로만 화면 변경이 가능하게 했을 때 개선될 것이라 생각됩니다. 조금 더 수정이 필요합니다. 