### PR TITLE
[Fix] 프로필 메모리스트에서 작성자의 이름이 제대로 표시되게 수정

### DIFF
--- a/MyMemory/MyMemory/View/Authentication/ProfileMemoList.swift
+++ b/MyMemory/MyMemory/View/Authentication/ProfileMemoList.swift
@@ -46,6 +46,7 @@ struct ProfileMemoList<ViewModel: ProfileViewModelProtocol>: View {
                                             self.isLoadingFetchMemos = false
                                         } else if let otherUserViewModel = viewModel as? OtherUserViewModel {
                                             self.isLoadingFetchMemos = true
+                                            self.profile = otherUserViewModel.memoCreator.toProfile
                                             let userId = otherUserViewModel.memoCreator.id?.description
                                             await otherUserViewModel.pagenate(userID: userId ?? "")
                                             self.isLoadingFetchMemos = false


### PR DESCRIPTION
# PR 가이드라인
## PR Checklist
PR 날릴 때 체크 리스트

- [x] 코드 컨벤션을 잘 지키셨나요?
- [x] 이슈 체크리스트를 잘 반영했나요?
- [x] Conflict 문제가 발생하지는 않나요?

## PR Type
어떤 종류의 PR인가요?

<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 새 기능 개발
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 문서 작업 변경
- [ ] 기타 작업

## 연관되는 issue 정보를 알려주세요

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #205 

# PR 설명하기
이 PR에 대해 간략하게 소개해주세요!

## 어떻게 작동하나요? code 기반으로 설명해주세요
```swift
// 해당 코드 한줄만 추가 됨
self.profile = otherUserViewModel.memoCreator.toProfile
```
ProfileMemoList에서 `profile`이 currentUser의 프로필을 자동으로 받아오는 구조기 때문에 
ProfileMemoLis가 OtherUserViewModel을 받을 때 `profile`의 값을 갱신하도록 했습니다.

---
