### PR TITLE
[Bug]: 작성하기 후 마이페이지 접근 시 무한로딩이 발생하는 경우를 해결하였습니다.

### DIFF
--- a/MyMemory/MyMemory/ViewModel/Post/PostViewModel.swift
+++ b/MyMemory/MyMemory/ViewModel/Post/PostViewModel.swift
@@ -108,6 +108,7 @@ class PostViewModel: ObservableObject {
                 loading = true
                 guard let user = AuthService.shared.currentUser else {
                     loading = false
+                    LoadingManager.shared.phase = .fail(msg: "로그인 중이 아님")
                     return
                 }
                 let newMemo = PostMemoModel(
@@ -128,16 +129,16 @@ class PostViewModel: ObservableObject {
                 do {
                     try await MemoService.shared.uploadMemo(newMemo: newMemo)
                     loading = false
-                    
-                    
+                    LoadingManager.shared.phase = .success
                 }
                 dismissPublisher.send(true)
                 resetMemoFields()
                 loading = false
-                
+                LoadingManager.shared.phase = .success
             } catch {
                 // 오류 처리
                 loading = false
+                LoadingManager.shared.phase = .fail(msg: error.localizedDescription)
                 print("Error signing in: \(error.localizedDescription)")
             }
         }


### PR DESCRIPTION
# PR 가이드라인
## PR Checklist
PR 날릴 때 체크 리스트

- [x] 코드 컨벤션을 잘 지키셨나요?
- [x] 이슈 체크리스트를 잘 반영했나요?
- [x] Conflict 문제가 발생하지는 않나요?

## PR Type
어떤 종류의 PR인가요?

<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 새 기능 개발
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 문서 작업 변경
- [ ] 기타 작업

## 연관되는 issue 정보를 알려주세요

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# PR 설명하기
작성하기 후 마이페이지 접근 시 무한로딩이 발생하는 경우를 해결하였습니다.
- 기존의 PostView에서 저장버튼을 누를 경우, `LoadingManager`를 통해 Loading 상태관리를 했으나, `saveMemo`메서드 내에서는 `LoadingManager`가 아닌 다른 loading을 관리해서 로딩상태가 항상 `.loading` 상태로 유지되어있던 걸로 파악됩니다.

## 어떻게 작동하나요? code 기반으로 설명해주세요
`LoadingManager`를 이용하여 로딩상태를 업데이트하는 코드를 추가했습니다.
```swift
func saveMemo() {
        Task{@MainActor in
            
            do {
                loading = true
                guard let user = AuthService.shared.currentUser else {
                    loading = false
                    LoadingManager.shared.phase = .fail(msg: "로그인 중이 아님") // 추가!
                    return
                }
                let newMemo = PostMemoModel(
                    userUid: user.id ?? "",
                    userCoordinateLatitude: Double(userCoordinate!.latitude),
                    userCoordinateLongitude: Double(userCoordinate!.longitude),
                    userAddress: memoAddressText,
                    userAddressBuildingName: memoAddressBuildingName,
                    memoTitle: memoTitle,
                    memoContents: memoContents,
                    isPublic: !memoShare,
                    memoTagList: memoSelectedTags,
                    memoLikeCount: 0,
                    memoSelectedImageData: memoSelectedImageData,
                    memoCreatedAt: Date().timeIntervalSince1970
                )
                
                do {
                    try await MemoService.shared.uploadMemo(newMemo: newMemo)
                    loading = false
                    LoadingManager.shared.phase = .success
                }
                dismissPublisher.send(true)
                resetMemoFields()
                loading = false
                LoadingManager.shared.phase = .success // 추가!
            } catch {
                // 오류 처리
                loading = false
                LoadingManager.shared.phase = .fail(msg: error.localizedDescription) // 추가!
                print("Error signing in: \(error.localizedDescription)")
            }
        }
    }

```

---

# 가능하다면 추가해주세요

## 변경 사항 스크린샷 혹은 화면 녹화

스크린샷

## Test 여부
### Test 정보
```swift
//예시
let testDatas: [TestData] = [.init(...),...]
```
## 기타 언급해야 할 사항들

- 정보 1
- 정보 2
