### PR TITLE
[Refactoring]: 기존의 회원탈퇴 로직에서 회원의 프로필 사진을 Storage에서 삭제하는 코드를 추가하였습니다.

### DIFF
--- a/MyMemory/MyMemory/Source/API/AuthService.swift
+++ b/MyMemory/MyMemory/Source/API/AuthService.swift
@@ -20,6 +20,8 @@ final class AuthService: ObservableObject {
     @Published var followingCount: Int = 0
     @Published var isFollow: Bool = false
     
+    let storage = Storage.storage()
+    
     init() {
         if let session = Auth.auth().currentUser {
             self.userSession = session
@@ -472,6 +474,37 @@ final class AuthService: ObservableObject {
             try await COLLECTION_MEMOS.document(memoID).updateData(["isPinned": memo.isPinned])
         } catch {
             print(error.localizedDescription)
+        }
+    }
+    
+    /// 사용자의 프로필사진을 제거하는 메서드입니다.
+    /// - Parameters:
+    ///     - uid: 사용자의 UID값입니다.
+    /// - Returns: 삭제에 성공하거나, 삭제할 프로필 사진이 없는 경우 .success(true)값을 반환하고, 삭제에 실패할 경우 .failure(.deleteUserProfileImage)를 반환합니다.
+    func removeUserProfileImage(uid: String) async -> Result<Bool, ProfileEditErrorType> {
+        let userRef = COLLECTION_USERS.document(uid)
+        let storageRef = storage.reference()
+        var deleteImageURL: String?
+        
+        do {
+            let user = try await userRef.getDocument()
+            if user.exists {
+                deleteImageURL = user["profilePicture"] as? String
+            }
+            
+            if let deleteImage = deleteImageURL, !deleteImage.isEmpty {
+                let deleteImageRef = storageRef.child("profile_images/\(deleteImage.getProfileImageUID())")
+                do {
+                    try await deleteImageRef.delete()
+                    return .success(true)
+                } catch {
+                    return .failure(.deleteUserProfileImage)
+                }
+            }
+            // 삭제할 이미지가 없는 경우(프로필 사진을 설정하지 않았던 경우)
+            return .success(true)
+        } catch {
+            return .failure(.deleteUserProfileImage)
         }
     }
 }

--- a/MyMemory/MyMemory/Source/API/MemoService.swift
+++ b/MyMemory/MyMemory/Source/API/MemoService.swift
@@ -820,12 +820,16 @@ extension MemoService {
            Authentication - 사용자 인증 기록 지우기
          
          */
-        
-        self.removeMemoData(uid: uid)
-        self.removeUserLikes(uid: uid)
-        self.removeUserFollowingAndFollowData(uid: uid)
-        self.removeUser(uid: uid)
-        
+        Task {
+            self.removeMemoData(uid: uid)
+            self.removeUserLikes(uid: uid)
+            self.removeUserFollowingAndFollowData(uid: uid)
+            let deleteImageResult = await AuthService.shared.removeUserProfileImage(uid: uid)
+            if let _ = try? deleteImageResult.get() {
+                print("사진 삭제 성공")
+            }
+            self.removeUser(uid: uid)
+        }
         // Authentication 계정 삭제
         if let currentUser = Auth.auth().currentUser {
             currentUser.delete { error in

--- a/MyMemory/MyMemory/View/Setting/SettingMenu/WithdrawalView.swift
+++ b/MyMemory/MyMemory/View/Setting/SettingMenu/WithdrawalView.swift
@@ -77,11 +77,13 @@ struct WithdrawalView: View {
                 }
                 
                 Button {
-                    MemoService.shared.removeUserAllData(uid: user?.id ?? "")
-                    isCurrentUserLoginState = false
-                    viewModel.isShowingWithdrawalAlert = true
-                    viewModel.fetchUserLogout {
-                        
+                    Task {
+                        await MemoService.shared.removeUserAllData(uid: user?.id ?? "")
+                        isCurrentUserLoginState = false
+                        viewModel.isShowingWithdrawalAlert = true
+                        viewModel.fetchUserLogout {
+                            
+                        }
                     }
                 } label: {
                     Text("네 그래도 탈퇴할게요")

--- a/MyMemory/MyMemory/ViewModel/Authentication/ProfileEditViewModel.swift
+++ b/MyMemory/MyMemory/ViewModel/Authentication/ProfileEditViewModel.swift
@@ -41,27 +41,16 @@ class ProfileEditViewModel: ObservableObject {
         }
         
         let userRef = COLLECTION_USERS.document(uid)
-        var deleteImageURL: String?
+        let deleteProfileImageResult = await AuthService.shared.removeUserProfileImage(uid: uid)
+        
+        guard let _ = try? deleteProfileImageResult.get() else {
+            return .failure(.deleteUserProfileImage)
+        }
+        
         do {
-            let user = try await userRef.getDocument()
-            if user.exists {
-                deleteImageURL = user["profilePicture"] as? String
-            }
             try await userRef.updateData([
                 "profilePicture": imageURL
             ])
-            try await userRef.updateData([
-                "name": name
-            ])
-            if let deleteImage = deleteImageURL, !deleteImage.isEmpty {
-                let deleteImageRef = storageRef
-                                        .child("profile_images/\(deleteImage.getProfileImageUID())")
-                do {
-                    try await deleteImageRef.delete()
-                } catch {
-                    return .failure(.deleteUserProfileImage)
-                }
-            }
             return .success(true)
         } catch {
             isLoading = false


### PR DESCRIPTION
# PR 가이드라인
## PR Checklist
PR 날릴 때 체크 리스트

- [x] 코드 컨벤션을 잘 지키셨나요?
- [x] 이슈 체크리스트를 잘 반영했나요?
- [x] Conflict 문제가 발생하지는 않나요?

## PR Type
어떤 종류의 PR인가요?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [ ] 새 기능 개발
- [ ] 코드 스타일 변경
- [x] 리팩토링
- [ ] 문서 작업 변경
- [x] 기타 작업

## 연관되는 issue 정보를 알려주세요

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #211 #212 

# PR 설명하기
기존의 회원탈퇴 로직에서 회원의 프로필 사진을 Storage에서 삭제하는 코드를 추가하였습니다.
- 기존에 프로필 수정 시 이전 프로필 사진을 Storage에서 삭제하는 로직을 사용하고 있어, 이를 `AuthService`로 분리 시켜 다른 곳에서도 사용할 수 있도록 분리하였습니다.

## 어떻게 작동하나요? code 기반으로 설명해주세요
```swift
    func removeUserProfileImage(uid: String) async -> Result<Bool, ProfileEditErrorType> {
        let userRef = COLLECTION_USERS.document(uid)
        let storageRef = storage.reference()
        var deleteImageURL: String?
        
        do {
            let user = try await userRef.getDocument()
            if user.exists {
                deleteImageURL = user["profilePicture"] as? String
            }
            
            if let deleteImage = deleteImageURL, !deleteImage.isEmpty {
                let deleteImageRef = storageRef.child("profile_images/\(deleteImage.getProfileImageUID())")
                do {
                    try await deleteImageRef.delete()
                    return .success(true)
                } catch {
                    return .failure(.deleteUserProfileImage)
                }
            }
            // 삭제할 이미지가 없는 경우(프로필 사진을 설정하지 않았던 경우)
            return .success(true)
        } catch {
            return .failure(.deleteUserProfileImage)
        }
    }
```

---

# 가능하다면 추가해주세요

## 변경 사항 스크린샷 혹은 화면 녹화

스크린샷

## Test 여부
### Test 정보
```swift
//예시
let testDatas: [TestData] = [.init(...),...]
```
## 기타 언급해야 할 사항들

- 정보 1
- 정보 2
