### PR TITLE
[Fix] 로그인 뷰 오류 수정

### DIFF
--- a/MyMemory/MyMemory.xcodeproj/project.pbxproj
+++ b/MyMemory/MyMemory.xcodeproj/project.pbxproj
@@ -126,7 +126,7 @@
 		DA3325BD2B6B4FB500DC9452 /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3325BC2B6B4FB500DC9452 /* PushNotification.swift */; };
 		DA3C24FA2B550FAA00425288 /* KakaoMapsSDK_SPM in Frameworks */ = {isa = PBXBuildFile; productRef = DA3C24F92B550FAA00425288 /* KakaoMapsSDK_SPM */; };
 		DA3D86B62B5E797D00D9DB3C /* ChangeLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3D86B52B5E797D00D9DB3C /* ChangeLocationView.swift */; };
-		DA461A342B7E386600C02203 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		DA461A342B7E386600C02203 /* TermsView.swift in Sources */ = {isa = PBXBuildFile; };
 		DA52B5DC2B5609EB003F5E59 /* GetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52B5DB2B5609EA003F5E59 /* GetAddress.swift */; };
 		DA52B5DE2B560E83003F5E59 /* AddressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52B5DD2B560E83003F5E59 /* AddressModel.swift */; };
 		DA58C2662B5CD74E005CB3B3 /* view+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA58C2652B5CD74E005CB3B3 /* view+Extension.swift */; };
@@ -1235,7 +1235,7 @@
 				01E6A6432B4683090061F08C /* PostView.swift in Sources */,
 				01E6A6352B467FE80061F08C /* MainTabView.swift in Sources */,
 				DA3D86B62B5E797D00D9DB3C /* ChangeLocationView.swift in Sources */,
-				DA461A342B7E386600C02203 /* (null) in Sources */,
+				DA461A342B7E386600C02203 /* TermsView.swift in Sources */,
 				DA2AD09C2B7339E90052F69C /* MypageTopView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MyMemory/MyMemory.xcodeproj/project.pbxproj
+++ b/MyMemory/MyMemory.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		28BB13352B568FE7001A4C0C /* ImgDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BB13342B568FE7001A4C0C /* ImgDetailView.swift */; };
 		28BB13372B56900B001A4C0C /* MemoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BB13362B56900B001A4C0C /* MemoDetailView.swift */; };
 		28BB13392B569075001A4C0C /* CertificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BB13382B569075001A4C0C /* CertificationView.swift */; };
+		28E44FC62B7F3FFF00D46F64 /* UIApplication+Extesions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E44FC52B7F3FFF00D46F64 /* UIApplication+Extesions.swift */; };
 		28F26D3F2B551E8500CE783D /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F26D3E2B551E8500CE783D /* LoginViewModel.swift */; };
 		641A8B3F2B57CBD500A942A1 /* MemoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641A8B3E2B57CBD500A942A1 /* MemoService.swift */; };
 		6452621A2B6A2776004FE5C7 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645262192B6A2776004FE5C7 /* DetailViewModel.swift */; };
@@ -125,7 +126,7 @@
 		DA3325BD2B6B4FB500DC9452 /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3325BC2B6B4FB500DC9452 /* PushNotification.swift */; };
 		DA3C24FA2B550FAA00425288 /* KakaoMapsSDK_SPM in Frameworks */ = {isa = PBXBuildFile; productRef = DA3C24F92B550FAA00425288 /* KakaoMapsSDK_SPM */; };
 		DA3D86B62B5E797D00D9DB3C /* ChangeLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3D86B52B5E797D00D9DB3C /* ChangeLocationView.swift */; };
-		DA461A342B7E386600C02203 /* TermsView.swift in Sources */ = {isa = PBXBuildFile; };
+		DA461A342B7E386600C02203 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		DA52B5DC2B5609EB003F5E59 /* GetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52B5DB2B5609EA003F5E59 /* GetAddress.swift */; };
 		DA52B5DE2B560E83003F5E59 /* AddressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52B5DD2B560E83003F5E59 /* AddressModel.swift */; };
 		DA58C2662B5CD74E005CB3B3 /* view+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA58C2652B5CD74E005CB3B3 /* view+Extension.swift */; };
@@ -241,6 +242,7 @@
 		28BB13342B568FE7001A4C0C /* ImgDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImgDetailView.swift; sourceTree = "<group>"; };
 		28BB13362B56900B001A4C0C /* MemoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailView.swift; sourceTree = "<group>"; };
 		28BB13382B569075001A4C0C /* CertificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificationView.swift; sourceTree = "<group>"; };
+		28E44FC52B7F3FFF00D46F64 /* UIApplication+Extesions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extesions.swift"; sourceTree = "<group>"; };
 		28F26D3E2B551E8500CE783D /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		641A8B3E2B57CBD500A942A1 /* MemoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoService.swift; sourceTree = "<group>"; };
 		645262172B6A26F7004FE5C7 /* Fonts+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fonts+Extensions.swift"; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				DA131A4D2B4BE0ED00743FD0 /* CornerShape.swift */,
 				645262172B6A26F7004FE5C7 /* Fonts+Extensions.swift */,
 				DA7481A52B6B7A5B00127B83 /* Time+Extensions.swift */,
+				28E44FC52B7F3FFF00D46F64 /* UIApplication+Extesions.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1213,6 +1216,7 @@
 				01A19D6D2B5D176C0031ABCB /* NavigationBar+Modifier.swift in Sources */,
 				649128F02B550C0A0034F567 /* SelectPhotos.swift in Sources */,
 				6A9BB1D02B6B762300AD04F7 /* MainSectionsView.swift in Sources */,
+				28E44FC62B7F3FFF00D46F64 /* UIApplication+Extesions.swift in Sources */,
 				01FB9F8F2B6BBF700021CE7F /* ThemeViewModel.swift in Sources */,
 				280561F02B67799000D9B9B6 /* AlertButtonView.swift in Sources */,
 				0117B8422B7D9897002C848D /* MemoThemeView.swift in Sources */,
@@ -1231,7 +1235,7 @@
 				01E6A6432B4683090061F08C /* PostView.swift in Sources */,
 				01E6A6352B467FE80061F08C /* MainTabView.swift in Sources */,
 				DA3D86B62B5E797D00D9DB3C /* ChangeLocationView.swift in Sources */,
-				DA461A342B7E386600C02203 /* TermsView.swift in Sources */,
+				DA461A342B7E386600C02203 /* (null) in Sources */,
 				DA2AD09C2B7339E90052F69C /* MypageTopView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MyMemory/MyMemory/Source/Extension/UIApplication+Extesions.swift
+++ b/MyMemory/MyMemory/Source/Extension/UIApplication+Extesions.swift
@@ -1,0 +1,26 @@
+//
+//  UIApplication+Extesions.swift
+//  MyMemory
+//
+//  Created by 김성엽 on 2/16/24.
+//
+
+import Foundation
+import SwiftUI
+
+// 화면 터치 시 키보드 내리기
+extension UIApplication {
+  func hideKeyboard() {
+    guard let scene = connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else { return }
+    let tapRecognizer = UITapGestureRecognizer(target: scene.windows.first, action: #selector(UIView.endEditing))
+    tapRecognizer.cancelsTouchesInView = false
+    tapRecognizer.delegate = self
+    scene.windows.first?.addGestureRecognizer(tapRecognizer)
+  }
+}
+ 
+extension UIApplication: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false
+    }
+}

--- a/MyMemory/MyMemory/View/Authentication/LoginView.swift
+++ b/MyMemory/MyMemory/View/Authentication/LoginView.swift
@@ -27,7 +27,6 @@ struct LoginView: View {
     
     @State private var email: String = ""
     @State private var password: String = ""
-    @State private var clearText: String = ""
     @State private var isActive: Bool = false
     @State private var isNewUser: Bool = false
     @State private var isNewGoogleUser: Bool = false
@@ -64,7 +63,6 @@ struct LoginView: View {
                             .textInputAutocapitalization(.never)// 대문자x
                             .focused($focusedField, equals: .email)
                             .textContentType(.emailAddress)
-                            .focused($isFocused)
                             .clearButton(text: $email)
                         
                     }
@@ -79,11 +77,13 @@ struct LoginView: View {
                             .textInputAutocapitalization(.never)
                             .focused($focusedField, equals: .password)
                             .textContentType(.password)
-                            .focused($isFocused)
                             .clearButton(text: $password)
                         
                     }
                 } //:VSTACK - TextField
+                .onAppear {
+                    UIApplication.shared.hideKeyboard()
+                }
                 .onSubmit {
                     switch focusedField {
                     case .email:
@@ -309,9 +309,6 @@ struct LoginView: View {
                 }
             }
         }//: NAVISTACK
-        .onTapGesture {
-                isFocused = false
-        }
         .moahAlert(isPresented: $isShowingLoginErrorAlert, moahAlert: {
             MoahAlertView(message: loginErrorAlertTitle, firstBtn: MoahAlertButtonView(type: .CONFIRM, isPresented: $isShowingLoginErrorAlert, action: {}))
         })

--- a/MyMemory/MyMemory/View/Authentication/LoginView.swift
+++ b/MyMemory/MyMemory/View/Authentication/LoginView.swift
@@ -37,7 +37,6 @@ struct LoginView: View {
     @State var appleCredential: ASAuthorizationAppleIDCredential?
     @State var googleCredential: AuthCredential?
     @State var isAppleUser: Bool = false
-    @FocusState private var isFocused: Bool
     @EnvironmentObject var viewModel: AuthViewModel
     @Environment(\.presentationMode) var presentationMode
     


### PR DESCRIPTION
# PR 가이드라인
## PR Checklist
PR 날릴 때 체크 리스트

- [x] 코드 컨벤션을 잘 지키셨나요?
- [x] 이슈 체크리스트를 잘 반영했나요?
- [x] Conflict 문제가 발생하지는 않나요?

## PR Type
어떤 종류의 PR인가요?

<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정
- [ ] 새 기능 개발
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 문서 작업 변경
- [ ] 기타 작업

## 연관되는 issue 정보를 알려주세요

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# PR 설명하기
애플 로그인 버튼을 길게 눌러야 작동하는 오류가 다시 발생해 수정했습니다.

## 어떻게 작동하나요? code 기반으로 설명해주세요
```swift
extension UIApplication {
  func hideKeyboard() {
    guard let scene = connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else { return }
    let tapRecognizer = UITapGestureRecognizer(target: scene.windows.first, action: #selector(UIView.endEditing))
    tapRecognizer.cancelsTouchesInView = false
    tapRecognizer.delegate = self
    scene.windows.first?.addGestureRecognizer(tapRecognizer)
  }
}
 
extension UIApplication: UIGestureRecognizerDelegate {
    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
        return false
    }
}
```
- NavigtionStack에 onTapGesture를 이용해 키보드가 내려가게 했는데, clear버튼을 눌러도 키보드가 내려가고
과거 애플로그인 버튼 오류까지 발생했습니다.
 
- UIKit을 이용해 화면 터치 시 키보드가 내려가게 변경했습니다.

---

# 가능하다면 추가해주세요

## 변경 사항 스크린샷 혹은 화면 녹화

스크린샷


